### PR TITLE
graph: do not export defaultGraph type

### DIFF
--- a/graph/default_graph.go
+++ b/graph/default_graph.go
@@ -8,8 +8,9 @@ import (
 	"sync"
 )
 
-// DefaultGraph type implements all methods in Graph interface.
-type DefaultGraph struct {
+// defaultGraph is an internal default graph type that
+// implements all methods in Graph interface.
+type defaultGraph struct {
 	mu sync.Mutex // guards the following
 
 	// Vertices stores all vertices.
@@ -22,9 +23,9 @@ type DefaultGraph struct {
 	VertexToParents map[string]map[string]float64
 }
 
-// NewDefaultGraph returns a new DefaultGraph.
-func NewDefaultGraph() *DefaultGraph {
-	return &DefaultGraph{
+// newDefaultGraph returns a new defaultGraph.
+func newDefaultGraph() *defaultGraph {
+	return &defaultGraph{
 		Vertices:         make(map[string]bool),
 		VertexToChildren: make(map[string]map[string]float64),
 		VertexToParents:  make(map[string]map[string]float64),
@@ -34,20 +35,20 @@ func NewDefaultGraph() *DefaultGraph {
 	}
 }
 
-func (g *DefaultGraph) Init() {
-	// (X) g = NewDefaultGraph()
+func (g *defaultGraph) Init() {
+	// (X) g = newDefaultGraph()
 	// this only updates the pointer
 	//
-	*g = *NewDefaultGraph()
+	*g = *newDefaultGraph()
 }
 
-func (g *DefaultGraph) GetVertices() map[string]bool {
+func (g *defaultGraph) GetVertices() map[string]bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.Vertices
 }
 
-func (g *DefaultGraph) FindVertex(vtx string) bool {
+func (g *defaultGraph) FindVertex(vtx string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if _, ok := g.Vertices[vtx]; !ok {
@@ -56,7 +57,7 @@ func (g *DefaultGraph) FindVertex(vtx string) bool {
 	return true
 }
 
-func (g *DefaultGraph) AddVertex(vtx string) bool {
+func (g *defaultGraph) AddVertex(vtx string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if _, ok := g.Vertices[vtx]; !ok {
@@ -66,7 +67,7 @@ func (g *DefaultGraph) AddVertex(vtx string) bool {
 	return false
 }
 
-func (g *DefaultGraph) DeleteVertex(vtx string) bool {
+func (g *defaultGraph) DeleteVertex(vtx string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if _, ok := g.Vertices[vtx]; !ok {
@@ -93,7 +94,7 @@ func (g *DefaultGraph) DeleteVertex(vtx string) bool {
 	return true
 }
 
-func (g *DefaultGraph) AddEdge(vtx1, vtx2 string, weight float64) error {
+func (g *defaultGraph) AddEdge(vtx1, vtx2 string, weight float64) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if _, ok := g.Vertices[vtx1]; !ok {
@@ -127,7 +128,7 @@ func (g *DefaultGraph) AddEdge(vtx1, vtx2 string, weight float64) error {
 	return nil
 }
 
-func (g *DefaultGraph) ReplaceEdge(vtx1, vtx2 string, weight float64) error {
+func (g *defaultGraph) ReplaceEdge(vtx1, vtx2 string, weight float64) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if _, ok := g.Vertices[vtx1]; !ok {
@@ -153,7 +154,7 @@ func (g *DefaultGraph) ReplaceEdge(vtx1, vtx2 string, weight float64) error {
 	return nil
 }
 
-func (g *DefaultGraph) DeleteEdge(vtx1, vtx2 string) error {
+func (g *defaultGraph) DeleteEdge(vtx1, vtx2 string) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if _, ok := g.Vertices[vtx1]; !ok {
@@ -175,7 +176,7 @@ func (g *DefaultGraph) DeleteEdge(vtx1, vtx2 string) error {
 	return nil
 }
 
-func (g *DefaultGraph) GetWeight(vtx1, vtx2 string) (float64, error) {
+func (g *defaultGraph) GetWeight(vtx1, vtx2 string) (float64, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if _, ok := g.Vertices[vtx1]; !ok {
@@ -192,7 +193,7 @@ func (g *DefaultGraph) GetWeight(vtx1, vtx2 string) (float64, error) {
 	return 0.0, fmt.Errorf("there is not edge from %s to %s", vtx1, vtx2)
 }
 
-func (g *DefaultGraph) GetParents(vtx string) (map[string]bool, error) {
+func (g *defaultGraph) GetParents(vtx string) (map[string]bool, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if _, ok := g.Vertices[vtx]; !ok {
@@ -207,7 +208,7 @@ func (g *DefaultGraph) GetParents(vtx string) (map[string]bool, error) {
 	return rs, nil
 }
 
-func (g *DefaultGraph) GetChildren(vtx string) (map[string]bool, error) {
+func (g *defaultGraph) GetChildren(vtx string) (map[string]bool, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if _, ok := g.Vertices[vtx]; !ok {
@@ -275,7 +276,7 @@ func (g *DefaultGraph) GetChildren(vtx string) (map[string]bool, error) {
 //	    },
 //	}
 //
-func NewDefaultGraphFromJSON(rd io.Reader, graphID string) (*DefaultGraph, error) {
+func newDefaultGraphFromJSON(rd io.Reader, graphID string) (*defaultGraph, error) {
 	js := make(map[string]map[string]map[string]float64)
 	dec := json.NewDecoder(rd)
 	for {
@@ -289,7 +290,7 @@ func NewDefaultGraphFromJSON(rd io.Reader, graphID string) (*DefaultGraph, error
 		return nil, fmt.Errorf("%s does not exist", graphID)
 	}
 	gmap := js[graphID]
-	g := NewDefaultGraph()
+	g := newDefaultGraph()
 	for vtx1, mm := range gmap {
 		if !g.FindVertex(vtx1) {
 			g.AddVertex(vtx1)
@@ -304,7 +305,7 @@ func NewDefaultGraphFromJSON(rd io.Reader, graphID string) (*DefaultGraph, error
 	return g, nil
 }
 
-func (g *DefaultGraph) String() string {
+func (g *defaultGraph) String() string {
 	buf := new(bytes.Buffer)
 	for vtx1 := range g.Vertices {
 		cmap, _ := g.GetChildren(vtx1)

--- a/graph/default_graph_test.go
+++ b/graph/default_graph_test.go
@@ -13,7 +13,7 @@ func TestNewDefaultGraphFromJSON(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_00")
+	g, err := newDefaultGraphFromJSON(f, "graph_00")
 	if err != nil {
 		t.Error(err)
 	}
@@ -27,7 +27,7 @@ func TestNewDefaultGraphFromJSON(t *testing.T) {
 			t.Error(err)
 		}
 		defer f.Close()
-		g, err := NewDefaultGraphFromJSON(f, graph.Name)
+		g, err := newDefaultGraphFromJSON(f, graph.Name)
 		if err != nil {
 			t.Error(err)
 		}
@@ -54,7 +54,7 @@ func TestDefaultGraph_GetVertices(t *testing.T) {
 			t.Error(err)
 		}
 		defer f.Close()
-		g, err := NewDefaultGraphFromJSON(f, graph.Name)
+		g, err := newDefaultGraphFromJSON(f, graph.Name)
 		if err != nil {
 			t.Error(err)
 		}
@@ -71,7 +71,7 @@ func TestDefaultGraph_Init(t *testing.T) {
 			t.Error(err)
 		}
 		defer f.Close()
-		g, err := NewDefaultGraphFromJSON(f, graph.Name)
+		g, err := newDefaultGraphFromJSON(f, graph.Name)
 		if err != nil {
 			t.Error(err)
 		}
@@ -88,7 +88,7 @@ func TestDefaultGraph_DeleteVertex(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_01")
+	g, err := newDefaultGraphFromJSON(f, "graph_01")
 	if err != nil {
 		t.Error(err)
 	}
@@ -131,7 +131,7 @@ func TestDefaultGraph_DeleteEdge(t *testing.T) {
 	}
 	defer f.Close()
 
-	g, err := NewDefaultGraphFromJSON(f, "graph_01")
+	g, err := newDefaultGraphFromJSON(f, "graph_01")
 	if err != nil {
 		t.Error(err)
 	}
@@ -180,7 +180,7 @@ func TestDefaultGraph_ReplaceEdge(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_00")
+	g, err := newDefaultGraphFromJSON(f, "graph_00")
 	if err != nil {
 		t.Error(err)
 	}

--- a/graph/minimum_spanning_tree_test.go
+++ b/graph/minimum_spanning_tree_test.go
@@ -12,7 +12,7 @@ func TestDefaultGraph_Kruskal_13(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_13")
+	g, err := newDefaultGraphFromJSON(f, "graph_13")
 	if err != nil {
 		t.Error(err)
 	}
@@ -33,7 +33,7 @@ func TestDefaultGraph_Prim_13(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_13")
+	g, err := newDefaultGraphFromJSON(f, "graph_13")
 	if err != nil {
 		t.Error(err)
 	}

--- a/graph/shortest_path_test.go
+++ b/graph/shortest_path_test.go
@@ -13,7 +13,7 @@ func TestDefaultGraph_Dijkstra_03(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_03")
+	g, err := newDefaultGraphFromJSON(f, "graph_03")
 	if err != nil {
 		t.Error(err)
 	}
@@ -40,7 +40,7 @@ func TestDefaultGraph_Dijkstra_04(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_04")
+	g, err := newDefaultGraphFromJSON(f, "graph_04")
 	if err != nil {
 		t.Error(err)
 	}
@@ -67,7 +67,7 @@ func TestDefaultGraph_Dijkstra_09_0(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_09")
+	g, err := newDefaultGraphFromJSON(f, "graph_09")
 	if err != nil {
 		t.Error(err)
 	}
@@ -94,7 +94,7 @@ func TestDefaultGraph_Dijkstra_09_1(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_09")
+	g, err := newDefaultGraphFromJSON(f, "graph_09")
 	if err != nil {
 		t.Error(err)
 	}
@@ -121,7 +121,7 @@ func TestDefaultGraph_Dijkstra_10_0(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_10")
+	g, err := newDefaultGraphFromJSON(f, "graph_10")
 	if err != nil {
 		t.Error(err)
 	}
@@ -148,7 +148,7 @@ func TestDefaultGraph_Dijkstra_10_1(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_10")
+	g, err := newDefaultGraphFromJSON(f, "graph_10")
 	if err != nil {
 		t.Error(err)
 	}
@@ -175,7 +175,7 @@ func TestDefaultGraph_BellmanFord_11(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_11")
+	g, err := newDefaultGraphFromJSON(f, "graph_11")
 	if err != nil {
 		t.Error(err)
 	}
@@ -202,7 +202,7 @@ func TestDefaultGraph_BellmanFord_12(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_12")
+	g, err := newDefaultGraphFromJSON(f, "graph_12")
 	if err != nil {
 		t.Error(err)
 	}

--- a/graph/strongly_connected_components_test.go
+++ b/graph/strongly_connected_components_test.go
@@ -12,7 +12,7 @@ func TestDefaultGraph_Tarjan_14(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_14")
+	g, err := newDefaultGraphFromJSON(f, "graph_14")
 	if err != nil {
 		t.Error(err)
 	}
@@ -29,7 +29,7 @@ func TestDefaultGraph_Tarjan_15(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_15")
+	g, err := newDefaultGraphFromJSON(f, "graph_15")
 	if err != nil {
 		t.Error(err)
 	}

--- a/graph/topological_sort_test.go
+++ b/graph/topological_sort_test.go
@@ -14,7 +14,7 @@ func TestDefaultGraph_TopologicalSort_05(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_05")
+	g, err := newDefaultGraphFromJSON(f, "graph_05")
 	if err != nil {
 		t.Error(err)
 	}
@@ -31,7 +31,7 @@ func TestDefaultGraph_TopologicalSort_06(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_06")
+	g, err := newDefaultGraphFromJSON(f, "graph_06")
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,7 +48,7 @@ func TestDefaultGraph_TopologicalSort_07(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_07")
+	g, err := newDefaultGraphFromJSON(f, "graph_07")
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +66,7 @@ func TestDefaultGraph_TopologicalSort(t *testing.T) {
 			t.Error(err)
 		}
 		defer f.Close()
-		g, err := NewDefaultGraphFromJSON(f, graph.Name)
+		g, err := newDefaultGraphFromJSON(f, graph.Name)
 		if err != nil {
 			t.Error(err)
 		}

--- a/graph/traversal_test.go
+++ b/graph/traversal_test.go
@@ -12,7 +12,7 @@ func TestDefaultGraph_BFS(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_00")
+	g, err := newDefaultGraphFromJSON(f, "graph_00")
 	if err != nil {
 		t.Error(err)
 	}
@@ -29,7 +29,7 @@ func TestDefaultGraph_DFS(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_00")
+	g, err := newDefaultGraphFromJSON(f, "graph_00")
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func TestDefaultGraph_DFSRecursion(t *testing.T) {
 		t.Error(err)
 	}
 	defer f.Close()
-	g, err := NewDefaultGraphFromJSON(f, "graph_00")
+	g, err := newDefaultGraphFromJSON(f, "graph_00")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
The default graph implementation needs not be exported since the package
defines graph with interface.