### PR TITLE
Move test code out of testdata directory

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Gyu-Ho Lee
+Copyright (c) 2016 Google Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/graph/default_graph_test.go
+++ b/graph/default_graph_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gyuho/goraph/graph/testdata"
+	"github.com/gyuho/goraph/graph/testgraph"
 )
 
 func TestNewDefaultGraphInterface(t *testing.T) {
@@ -35,7 +35,7 @@ func TestNewDefaultGraphFromJSON(t *testing.T) {
 	if g.VertexToChildren["C"]["S"] != 9.0 {
 		t.Errorf("weight from C to S must be 9.0 but %f", g.VertexToChildren["C"]["S"])
 	}
-	for _, graph := range testdata.GraphSlice {
+	for _, graph := range testgraph.GraphSlice {
 		f, err := os.Open("testdata/graph.json")
 		if err != nil {
 			t.Error(err)
@@ -62,7 +62,7 @@ func TestNewDefaultGraphFromJSON(t *testing.T) {
 }
 
 func TestDefaultGraph_GetVertices(t *testing.T) {
-	for _, graph := range testdata.GraphSlice {
+	for _, graph := range testgraph.GraphSlice {
 		f, err := os.Open("testdata/graph.json")
 		if err != nil {
 			t.Error(err)
@@ -79,7 +79,7 @@ func TestDefaultGraph_GetVertices(t *testing.T) {
 }
 
 func TestDefaultGraph_Init(t *testing.T) {
-	for _, graph := range testdata.GraphSlice {
+	for _, graph := range testgraph.GraphSlice {
 		f, err := os.Open("testdata/graph.json")
 		if err != nil {
 			t.Error(err)

--- a/graph/testdata/doc.go
+++ b/graph/testdata/doc.go
@@ -1,2 +1,0 @@
-// Package testdata contains graph test data.
-package testdata // import "github.com/gyuho/goraph/graph/testdata"

--- a/graph/testgraph/doc.go
+++ b/graph/testgraph/doc.go
@@ -1,0 +1,2 @@
+// Package testgraph contains graph test data.
+package testgraph // import "github.com/gyuho/goraph/graph/testgraph"

--- a/graph/testgraph/graph.go
+++ b/graph/testgraph/graph.go
@@ -1,4 +1,4 @@
-package testdata
+package testgraph
 
 // Graph contains test data.
 type Graph struct {

--- a/graph/topological_sort_test.go
+++ b/graph/topological_sort_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gyuho/goraph/graph/testdata"
+	"github.com/gyuho/goraph/graph/testgraph"
 )
 
 func TestDefaultGraph_TopologicalSort_05(t *testing.T) {
@@ -60,7 +60,7 @@ func TestDefaultGraph_TopologicalSort_07(t *testing.T) {
 }
 
 func TestDefaultGraph_TopologicalSort(t *testing.T) {
-	for _, graph := range testdata.GraphSlice {
+	for _, graph := range testgraph.GraphSlice {
 		f, err := os.Open("testdata/graph.json")
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
Test code in the testdata directory breaks the convention used by
certain build system, where "testdata" only contains data such as images
and blobs.

This change moves the test data to a "testgraph" directory, to avoid
breaking such conventions.

Sorry for sending a patch before discussing it. If this is not acceptable, feel free to reject this change. :)

Also updating the copyright notice, as required by my employer.