### PR TITLE
Add error return value to GetNode() function

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,2 @@
 // Package goraph implements graph data structure and algorithms.
-package goraph // import "github.com/gyuho/goraph"
+package goraph // import "github.com/tcharding/goraph"

--- a/example_new_graph_test.go
+++ b/example_new_graph_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/gyuho/goraph"
+	"github.com/tcharding/goraph"
 )
 
 func ExampleNewGraph() {

--- a/graph.go
+++ b/graph.go
@@ -102,9 +102,9 @@ type Graph interface {
 	// GetNodeCount returns the total number of nodes.
 	GetNodeCount() int
 
-	// GetNode finds the Node. It returns nil if the Node
-	// does not exist in the graph.
-	GetNode(id ID) Node
+	// GetNode finds the Node. It returns an error if
+	// the Node does not exist in the graph.
+	GetNode(id ID) (Node, error)
 
 	// GetNodes returns a map from node ID to
 	// empty struct value. Graph does not allow duplicate
@@ -197,11 +197,15 @@ func (g *graph) GetNodeCount() int {
 	return len(g.idToNodes)
 }
 
-func (g *graph) GetNode(id ID) Node {
+func (g *graph) GetNode(id ID) (Node, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
-	return g.idToNodes[id]
+	if !g.unsafeExistID(id) {
+		return nil, fmt.Errorf("%s does not exist in the graph.", id)
+	}
+
+	return g.idToNodes[id], nil
 }
 
 func (g *graph) GetNodes() map[ID]Node {
@@ -480,24 +484,19 @@ func NewGraphFromJSON(rd io.Reader, graphID string) (Graph, error) {
 
 	g := newGraph()
 	for id1, mm := range gmap {
-		nd1 := g.GetNode(StringID(id1))
-		if nd1 == nil {
+		nd1, err := g.GetNode(StringID(id1))
+		if err != nil {
 			nd1 = NewNode(id1)
-			if ok := g.AddNode(nd1); !ok {
-				return nil, fmt.Errorf("%s already exists", nd1)
-			}
+			g.AddNode(nd1)
 		}
 		for id2, weight := range mm {
-			nd2 := g.GetNode(StringID(id2))
-			if nd2 == nil {
+			nd2, err := g.GetNode(StringID(id2))
+			if err != nil {
 				nd2 = NewNode(id2)
-				if ok := g.AddNode(nd2); !ok {
-					return nil, fmt.Errorf("%s already exists", nd2)
-				}
+				g.AddNode(nd2)
 			}
 			g.ReplaceEdge(nd1.ID(), nd2.ID(), weight)
 		}
 	}
-
 	return g, nil
 }

--- a/graph_test.go
+++ b/graph_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gyuho/goraph/testgraph"
+	"github.com/tcharding/goraph/testgraph"
 )
 
 func TestNewGraph(t *testing.T) {
@@ -113,8 +113,8 @@ func TestGraph_DeleteNode(t *testing.T) {
 	if !g.DeleteNode(StringID("D")) {
 		t.Fatal("D does not exist in the graph")
 	}
-	if g.GetNode(StringID("D")) != nil {
-		t.Fatalf("Expected Node but %s", g.GetNode(StringID("D")))
+	if nd, err := g.GetNode(StringID("D")); err == nil {
+		t.Fatalf("Expected no Node but got %s", nd)
 	}
 	if v, err := g.GetSources(StringID("C")); err != nil || len(v) != 1 {
 		t.Fatalf("Expected 1 edge incoming to C but %v\n\n%s", err, g)

--- a/minimum_spanning_tree.go
+++ b/minimum_spanning_tree.go
@@ -247,7 +247,15 @@ func Prim(g Graph, src ID) (map[Edge]struct{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		tree[NewEdge(g.GetNode(v), g.GetNode(k), weight)] = struct{}{}
+		src, err := g.GetNode(v)
+		if err != nil {
+			return nil, err
+		}
+		tgt, err := g.GetNode(k)
+		if err != nil {
+			return nil, err
+		}
+		tree[NewEdge(src, tgt, weight)] = struct{}{}
 	}
 	return tree, nil
 }

--- a/testgraph/doc.go
+++ b/testgraph/doc.go
@@ -1,2 +1,2 @@
 // Package testgraph contains graph test data.
-package testgraph // import "github.com/gyuho/goraph/testgraph"
+package testgraph // import "github.com/tcharding/goraph/testgraph"

--- a/topological_sort_test.go
+++ b/topological_sort_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gyuho/goraph/testgraph"
+	"github.com/tcharding/goraph/testgraph"
 )
 
 func TestGraph_TopologicalSort_05(t *testing.T) {

--- a/traversal.go
+++ b/traversal.go
@@ -20,7 +20,7 @@ package goraph
 //	14. 				label w as visited
 //
 func BFS(g Graph, id ID) []ID {
-	if g.GetNode(id) == nil {
+	if _, err := g.GetNode(id); err != nil {
 		return nil
 	}
 
@@ -83,7 +83,7 @@ func BFS(g Graph, id ID) []ID {
 //	16. 					S.push(w)
 //
 func DFS(g Graph, id ID) []ID {
-	if g.GetNode(id) == nil {
+	if _, err := g.GetNode(id); err != nil {
 		return nil
 	}
 
@@ -140,7 +140,7 @@ func DFS(g Graph, id ID) []ID {
 //	10. 			recursive DFS(G, u)
 //
 func DFSRecursion(g Graph, id ID) []ID {
-	if g.GetNode(id) == nil {
+	if _, err := g.GetNode(id); err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
GetNode currently returns nil for a non-existent node, however other
functions (for example GetTargets) return an error for a non-existent
node. This patch adds an error return value to GetNode to make it
consistent with the rest of the package.

This patch is not a merge candidate because it includes import path
changes. These were necessary in order to run travis build but clearly
another solution is needed. 