### PR TITLE
Add error return value to GetNode().

### DIFF
--- a/graph_test.go
+++ b/graph_test.go
@@ -113,8 +113,8 @@ func TestGraph_DeleteNode(t *testing.T) {
 	if !g.DeleteNode(StringID("D")) {
 		t.Fatal("D does not exist in the graph")
 	}
-	if g.GetNode(StringID("D")) != nil {
-		t.Fatalf("Expected Node but %s", g.GetNode(StringID("D")))
+	if nd, err := g.GetNode(StringID("D")); err == nil {
+		t.Fatalf("No Node Expected but got %s", nd)
 	}
 	if v, err := g.GetSources(StringID("C")); err != nil || len(v) != 1 {
 		t.Fatalf("Expected 1 edge incoming to C but %v\n\n%s", err, g)

--- a/minimum_spanning_tree.go
+++ b/minimum_spanning_tree.go
@@ -247,7 +247,15 @@ func Prim(g Graph, src ID) (map[Edge]struct{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		tree[NewEdge(g.GetNode(v), g.GetNode(k), weight)] = struct{}{}
+		src, err := g.GetNode(v)
+		if err != nil {
+			return nil, err
+		}
+		tgt, err := g.GetNode(k)
+		if err != nil {
+			return nil, err
+		}
+		tree[NewEdge(src, tgt, weight)] = struct{}{}
 	}
 	return tree, nil
 }

--- a/traversal.go
+++ b/traversal.go
@@ -20,7 +20,7 @@ package goraph
 //	14. 				label w as visited
 //
 func BFS(g Graph, id ID) []ID {
-	if g.GetNode(id) == nil {
+	if _, err := g.GetNode(id); err != nil {
 		return nil
 	}
 
@@ -83,7 +83,7 @@ func BFS(g Graph, id ID) []ID {
 //	16. 					S.push(w)
 //
 func DFS(g Graph, id ID) []ID {
-	if g.GetNode(id) == nil {
+	if _, err := g.GetNode(id); err != nil {
 		return nil
 	}
 
@@ -140,7 +140,7 @@ func DFS(g Graph, id ID) []ID {
 //	10. 			recursive DFS(G, u)
 //
 func DFSRecursion(g Graph, id ID) []ID {
-	if g.GetNode(id) == nil {
+	if _, err := g.GetNode(id); err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
Currently GetNode returns nil (zero value for map) if GetNode is passed
a non-existent ID. Other functions in the package return an error value
in this case, func (g *graph) GetTargets(id ID) (map[ID]Node, error).

This patch adds an error return value to GetNode(). Also updates all
call sites and tests. Slightly improves error detection in Prim()
(minimum_spanning_tree.go)